### PR TITLE
Updated the readme to reflect the switch to GitHub projects from Trello

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ We're building our own version of this FreeCodeCamp assignment: the Drum Machine
 
 https://learn.freecodecamp.org/front-end-libraries/front-end-libraries-projects/build-a-drum-machine/
 
-This is the shared repo for our source code. We'll be utilizing Discord for communcation and Trello to track progress. Send us a message if you'd like to be involved.
+This is the shared repo for our source code. We'll be utilizing Discord for communcation and GitHub projects to track progress. Send us a message if you'd like to be involved.
 
-https://trello.com/b/BSjHexcH/drum-camp
+https://github.com/nashvillefcc/drumcamp/projects/1
 
 ## Frameworks:
 We'll be starting the application with Bootstrap and jQuery. Refer below for documentation:


### PR DESCRIPTION
This is just a small edit to the readme, as it still said that we were using the Trello board (as I understand it, we aren't).